### PR TITLE
feat: Implement local multiplayer mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,45 +11,43 @@
     <div class="container">
       <h1>Puyo Puyo 🎮</h1>
       <div class="gameContainer">
-        <div class="gameDiv">
-          <h3>
-            <i class="fa fa-star"></i> Score: <span id="puntuation">0</span>
-          </h3>
-          <canvas id="gameCanvas" width="300" height="600"></canvas>
-          <div class="mobileControls">
-            <button id="rotate">
-              Rotate
-            </button>
-            <button id="left">
-              Left
-            </button>
-            <button id="right">
-              Right
-            </button>
-            <button id="drop">
-               Drop
-            </button>
-          </div>
-        </div>
-        <div class="side">
-          <div class="instructions">
-            <h3>📋 Instructions</h3>
-            <ul>
-              <li>Move: Arrow keys</li>
-              <li>Rotate: Space</li>
-              <li>Drop: Down arrow</li>
-              <li>Restart: R</li>
-            </ul>
-            <p>
-              Position the Puyos to create groups of four or more same-colored
-              Puyos. The goal is to connect four or more Puyos in any direction
-              (horizontal, vertical) to make them disappear and score points.
-            </p>
-          </div>
+        <div class="player-container" id="player1Container">
+          <h3>Player 1 Score: <span id="puntuation1">0</span></h3>
+          <canvas id="gameCanvas1" width="300" height="600"></canvas>
           <div class="nextPuyoDiv">
             <h3>Next Puyo:</h3>
-            <canvas id="nextPuyoCanvas" width="150" height="150"> </canvas>
+            <canvas id="nextPuyoCanvas1" width="150" height="150"></canvas>
           </div>
+        </div>
+        <div class="player-container" id="player2Container">
+          <h3>Player 2 Score: <span id="puntuation2">0</span></h3>
+          <canvas id="gameCanvas2" width="300" height="600"></canvas>
+          <div class="nextPuyoDiv">
+            <h3>Next Puyo:</h3>
+            <canvas id="nextPuyoCanvas2" width="150" height="150"></canvas>
+          </div>
+        </div>
+      </div>
+      <div class="mobileControls">
+        <button id="rotate">Rotate</button>
+        <button id="left">Left</button>
+        <button id="right">Right</button>
+        <button id="drop">Drop</button>
+      </div>
+      <div class="side">
+        <div class="instructions">
+          <h3>📋 Instructions</h3>
+          <ul>
+            <li>Move: Arrow keys</li>
+            <li>Rotate: Space</li>
+            <li>Drop: Down arrow</li>
+            <li>Restart: R</li>
+          </ul>
+          <p>
+            Position the Puyos to create groups of four or more same-colored
+            Puyos. The goal is to connect four or more Puyos in any direction
+            (horizontal, vertical) to make them disappear and score points.
+          </p>
         </div>
       </div>
       <script type="module" src="/main.js"></script>

--- a/style.css
+++ b/style.css
@@ -32,47 +32,55 @@ canvas {
   gap: 10px;
 }
 
+.player-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px; /* Added gap for elements within player container */
+  border: 1px solid #555; /* Added border for visual distinction */
+  padding: 10px; /* Added padding */
+  border-radius: 8px; /* Added border-radius */
+  flex: 1; /* Allow player containers to grow equally */
+}
+
 .container {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  max-width: 500px;
+  max-width: 900px; /* Increased max-width for two players */
 }
 
-@media screen and (max-width: 500px) {
+@media screen and (max-width: 768px) { /* Adjusted breakpoint for better responsiveness */
   .gameContainer {
-    flex-direction: column-reverse;
+    flex-direction: column; /* Changed to column for P1 on top of P2 */
     align-items: center;
   }
   .side {
-    flex-direction: column-reverse;
+    /* flex-direction: column-reverse; // Keep as is or change to column if preferred */
     align-items: center;
   }
 
   .container {
     align-items: center;
+    max-width: 500px; /* Adjust container width for stacked view */
   }
 }
 
-.gameDiv {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
+/* Removed .gameDiv as it's replaced by .player-container */
 
 .nextPuyoDiv {
   display: flex;
   flex-direction: column;
-  justify-content: left;
-  gap: 10px;
-  align-items: start;
+  /* justify-content: left; // Removed for centering */
+  gap: 5px; /* Adjusted gap */
+  align-items: center; /* Changed to center */
 }
 
 .side {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  max-width: 200px;
+  max-width: 100%; /* Allow side to take full width if needed on small screens */
 }
 
 .instructions {
@@ -91,6 +99,7 @@ canvas {
   display: flex;
   justify-content: center;
   gap: 10px;
+  width: 100%; /* Ensure controls take full width if centered in container */
 }
 
 .mobileControls button {


### PR DESCRIPTION
This commit introduces a local two-player mode to the Puyo Puyo game.

Key changes include:
- Refactored core game logic to be player-centric, encapsulating state (board, score, puyos, game over status) within a `Player` class.
- Updated HTML to create distinct game areas for two players, including separate game canvases, "next Puyo" displays, and scoreboards.
- Styled the UI with CSS to present the two player areas side-by-side on larger screens and stacked on smaller screens.
- Implemented separate keyboard controls:
    - Player 1: Arrow keys for movement, Spacebar for rotation.
    - Player 2: WASD keys for movement, 'W' key for rotation.
- Mobile/on-screen button controls are mapped to Player 1.
- The game loop now manages both players independently, tracking their scores, piece movements, collisions, and game over states.
- The game continues until both players are game over.
- Restart functionality ('R' key) resets the game for both players.